### PR TITLE
Use AsyncComputeTaskPool, to prevent starving IO threads.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ strum = { version = "0.24", features = ["derive"] }
 bevy_mod_picking = "0.12"
 
 [dependencies.bevy]
-version = "0.10"
+version = "0.11"
 default-features = false
 
 [dev-dependencies.bevy]
-version = "0.10"
+version = "0.11"
 features = ["bevy_core_pipeline","bevy_asset", "bevy_scene", "bevy_render", "bevy_winit", "bevy_gltf", "bevy_ui", "bevy_text"]
 default-features = false
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
-version = "0.10"
+version = "0.11"
 features = ["x11", "wayland"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_midi"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Black Phlox <bphlox@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -66,7 +66,9 @@ fn disconnect(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
 fn play_notes(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
     for (keycode, note) in &KEY_NOTE_MAP {
         if input.just_pressed(*keycode) {
-            output.send([0b1001_0000, *note, 127].into()); // Note on, channel 1, max velocity
+            let message: MidiMessage = [0b1001_0000, *note, 127].into();
+            error!("Sending message: {:?}", message);
+            output.send(message); // Note on, channel 1, max velocity
         }
         if input.just_released(*keycode) {
             output.send([0b1000_0000, *note, 127].into()); // Note on, channel 1, max velocity

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,9 +16,9 @@ impl Plugin for MidiInputPlugin {
             .init_resource::<MidiInputConnection>()
             .add_event::<MidiInputError>()
             .add_event::<MidiData>()
-            .add_startup_system(setup)
-            .add_system(reply.in_base_set(CoreSet::PreUpdate))
-            .add_system(debug);
+            .add_systems(Startup, setup)
+            .add_systems(PreUpdate, reply)
+            .add_systems(Update, debug);
     }
 }
 
@@ -106,14 +106,14 @@ impl MidiInputConnection {
 /// An [`Event`](bevy::ecs::event::Event) for incoming midi data.
 ///
 /// This event fires from [`CoreStage::PreUpdate`].
-#[derive(Resource)]
+#[derive(Resource, Event)]
 pub struct MidiData {
     pub stamp: u64,
     pub message: MidiMessage,
 }
 
 /// The [`Error`] type for midi input operations, accessible as an [`Event`](bevy::ecs::event::Event).
-#[derive(Clone, Debug)]
+#[derive(Event, Clone, Debug)]
 pub enum MidiInputError {
     ConnectionError(ConnectErrorKind),
     PortRefreshError,

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,8 +14,8 @@ impl Plugin for MidiOutputPlugin {
         app.init_resource::<MidiOutputSettings>()
             .init_resource::<MidiOutputConnection>()
             .add_event::<MidiOutputError>()
-            .add_startup_system(setup)
-            .add_system(reply.in_base_set(CoreSet::PreUpdate));
+            .add_systems(Startup, setup)
+            .add_systems(PreUpdate, reply);
     }
 }
 
@@ -98,7 +98,7 @@ impl MidiOutputConnection {
 }
 
 /// The [`Error`] type for midi output operations, accessible as an [`Event`](bevy::ecs::event::Event)
-#[derive(Clone, Debug)]
+#[derive(Event, Clone, Debug)]
 pub enum MidiOutputError {
     ConnectionError(ConnectErrorKind),
     SendError(midir::SendError),

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,5 @@
 use super::MidiMessage;
-use bevy::{prelude::*, tasks::IoTaskPool};
+use bevy::{prelude::*, tasks::AsyncComputeTaskPool};
 use crossbeam_channel::{Receiver, Sender};
 use midir::ConnectErrorKind;
 pub use midir::MidiOutputPort;
@@ -134,7 +134,7 @@ fn setup(mut commands: Commands, settings: Res<MidiOutputSettings>) {
     let (m_sender, m_receiver) = crossbeam_channel::unbounded();
     let (r_sender, r_receiver) = crossbeam_channel::unbounded();
 
-    let thread_pool = IoTaskPool::get();
+    let thread_pool = AsyncComputeTaskPool::get();
     thread_pool
         .spawn(midi_output(m_receiver, r_sender, settings.port_name))
         .detach();


### PR DESCRIPTION
Partially addresses #24. Now downstream apps might not be able to create AsyncCompute tasks on devices with low core count, but that is better than not being able to do IO.