### PR TITLE
Integration with `midly` for full MIDI message parsing / support using "Owned" message variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ name = "bevy_midi"
 [dependencies]
 midir = "0.9"
 crossbeam-channel = "0.5.8"
+midly = { version = "0.5.3", default-features = false, features = ["std", "alloc"] }
 
 [dev-dependencies]
 bevy_egui = { version = "0.23", features = ["immutable_ctx"]}

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -103,14 +103,14 @@ fn show_last_message(
 ) {
     for data in midi_data.read() {
         let text_section = &mut instructions.single_mut().sections[3];
-        let event_str = match data.message {
-            LiveEvent::Midi { channel, message } => {
+        let event_str = match &data.message {
+            OwnedLiveEvent::Midi { channel, message } => {
                 format!("Channel {channel} - {message:?}")
             }
-            LiveEvent::Common(sc) => {
+            OwnedLiveEvent::Common(sc) => {
                 format!("{:?}", sc)
             }
-            LiveEvent::Realtime(rt) => {
+            OwnedLiveEvent::Realtime(rt) => {
                 format!("{:?}", rt)
             }
         };

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -103,17 +103,18 @@ fn show_last_message(
 ) {
     for data in midi_data.read() {
         let text_section = &mut instructions.single_mut().sections[3];
-        text_section.value = format!(
-            "Last Message: {} - {:?}",
-            if data.message.is_note_on() {
-                "NoteOn"
-            } else if data.message.is_note_off() {
-                "NoteOff"
-            } else {
-                "Other"
-            },
-            data.message.msg
-        );
+        let event_str = match data.message {
+            LiveEvent::Midi { channel, message } => {
+                format!("Channel {channel} - {message:?}")
+            }
+            LiveEvent::Common(sc) => {
+                format!("{:?}", sc)
+            }
+            LiveEvent::Realtime(rt) => {
+                format!("{:?}", rt)
+            }
+        };
+        text_section.value = format!("Last Message: {:?}", event_str);
     }
 }
 

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -71,18 +71,11 @@ fn disconnect(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
 fn play_notes(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
     for (keycode, note) in &KEY_NOTE_MAP {
         let key: num::u7 = (*note).into();
-        let vel: num::u7 = 127.into();
         if input.just_pressed(*keycode) {
-            output.send(LiveEvent::Midi {
-                channel: 0.into(),
-                message: midly::MidiMessage::NoteOn { key, vel },
-            }); // Note on, channel 1, max velocity
+            output.send(OwnedLiveEvent::note_on(0, key, 127));
         }
         if input.just_released(*keycode) {
-            output.send(LiveEvent::Midi {
-                channel: 0.into(),
-                message: midly::MidiMessage::NoteOff { key, vel },
-            }); // Note on, channel 1, max velocity
+            output.send(OwnedLiveEvent::note_off(0, key, 127));
         }
     }
 }

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -70,12 +70,11 @@ fn disconnect(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
 
 fn play_notes(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
     for (keycode, note) in &KEY_NOTE_MAP {
-        let key: num::u7 = (*note).into();
         if input.just_pressed(*keycode) {
-            output.send(OwnedLiveEvent::note_on(0, key, 127));
+            output.send(OwnedLiveEvent::note_on(0, *note, 127));
         }
         if input.just_released(*keycode) {
-            output.send(OwnedLiveEvent::note_off(0, key, 127));
+            output.send(OwnedLiveEvent::note_off(0, *note, 127));
         }
     }
 }

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -70,11 +70,19 @@ fn disconnect(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
 
 fn play_notes(input: Res<Input<KeyCode>>, output: Res<MidiOutput>) {
     for (keycode, note) in &KEY_NOTE_MAP {
+        let key: num::u7 = (*note).into();
+        let vel: num::u7 = 127.into();
         if input.just_pressed(*keycode) {
-            output.send([0b1001_0000, *note, 127].into()); // Note on, channel 1, max velocity
+            output.send(LiveEvent::Midi {
+                channel: 0.into(),
+                message: midly::MidiMessage::NoteOn { key, vel },
+            }); // Note on, channel 1, max velocity
         }
         if input.just_released(*keycode) {
-            output.send([0b1000_0000, *note, 127].into()); // Note on, channel 1, max velocity
+            output.send(LiveEvent::Midi {
+                channel: 0.into(),
+                message: midly::MidiMessage::NoteOff { key, vel },
+            }); // Note on, channel 1, max velocity
         }
     }
 }

--- a/examples/piano.rs
+++ b/examples/piano.rs
@@ -147,30 +147,33 @@ fn handle_midi_input(
     query: Query<(Entity, &Key)>,
 ) {
     for data in midi_events.read() {
-	match data.message {
-	    OwnedLiveEvent::Midi { message: MidiMessage::NoteOn { key, .. }, .. } => {
-		let index: u8 = key.into();
-		let off = index % 12;
-		let oct = index.overflowing_div(12).0;
-		let key_str = KEY_RANGE.iter().nth(off.into()).unwrap();
+        match data.message {
+            OwnedLiveEvent::Midi {
+                message: MidiMessage::NoteOn { key, .. },
+                ..
+            } => {
+                let index: u8 = key.into();
+                let off = index % 12;
+                let oct = index.overflowing_div(12).0;
+                let key_str = KEY_RANGE.iter().nth(off.into()).unwrap();
 
-		if data.is_note_on() {
-		    for (entity, key) in query.iter() {
-			if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
-			    commands.entity(entity).insert(PressedKey);
-			}
-		    }
-		} else if data.is_note_off() {
-		    for (entity, key) in query.iter() {
-			if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
-			    commands.entity(entity).remove::<PressedKey>();
-			}
-		    }
-		} else {
-		}
-	    },
-	    _ => {}
-	}
+                if data.is_note_on() {
+                    for (entity, key) in query.iter() {
+                        if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
+                            commands.entity(entity).insert(PressedKey);
+                        }
+                    }
+                } else if data.is_note_off() {
+                    for (entity, key) in query.iter() {
+                        if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
+                            commands.entity(entity).remove::<PressedKey>();
+                        }
+                    }
+                } else {
+                }
+            }
+            _ => {}
+        }
     }
 }
 

--- a/examples/piano.rs
+++ b/examples/piano.rs
@@ -147,25 +147,30 @@ fn handle_midi_input(
     query: Query<(Entity, &Key)>,
 ) {
     for data in midi_events.read() {
-        let [_, index, _value] = data.message.msg;
-        let off = index % 12;
-        let oct = index.overflowing_div(12).0;
-        let key_str = KEY_RANGE.iter().nth(off.into()).unwrap();
+	match data.message {
+	    OwnedLiveEvent::Midi { message: MidiMessage::NoteOn { key, .. }, .. } => {
+		let index: u8 = key.into();
+		let off = index % 12;
+		let oct = index.overflowing_div(12).0;
+		let key_str = KEY_RANGE.iter().nth(off.into()).unwrap();
 
-        if data.message.is_note_on() {
-            for (entity, key) in query.iter() {
-                if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
-                    commands.entity(entity).insert(PressedKey);
-                }
-            }
-        } else if data.message.is_note_off() {
-            for (entity, key) in query.iter() {
-                if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
-                    commands.entity(entity).remove::<PressedKey>();
-                }
-            }
-        } else {
-        }
+		if data.is_note_on() {
+		    for (entity, key) in query.iter() {
+			if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
+			    commands.entity(entity).insert(PressedKey);
+			}
+		    }
+		} else if data.is_note_off() {
+		    for (entity, key) in query.iter() {
+			if key.key_val.eq(&format!("{}{}", key_str, oct).to_string()) {
+			    commands.entity(entity).remove::<PressedKey>();
+			}
+		    }
+		} else {
+		}
+	    },
+	    _ => {}
+	}
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-use crate::OwnedLiveEvent;
+use crate::types::OwnedLiveEvent;
 
 use bevy::prelude::Plugin;
 use bevy::{prelude::*, tasks::IoTaskPool};

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,8 +5,8 @@ use bevy::{prelude::*, tasks::IoTaskPool};
 use crossbeam_channel::{Receiver, Sender};
 use midir::ConnectErrorKind; // XXX: do we expose this?
 pub use midir::{Ignore, MidiInputPort};
-use midly::MidiMessage;
 use midly::stream::MidiStream;
+use midly::MidiMessage;
 use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
@@ -121,18 +121,24 @@ impl bevy::prelude::Event for MidiData {}
 impl MidiData {
     /// Return `true` iff the underlying message represents a MIDI note on event.
     pub fn is_note_on(&self) -> bool {
-	match self.message {
-	    OwnedLiveEvent::Midi { message: MidiMessage::NoteOn { .. }, .. } => true,
-	    _ => false
-	}
+        match self.message {
+            OwnedLiveEvent::Midi {
+                message: MidiMessage::NoteOn { .. },
+                ..
+            } => true,
+            _ => false,
+        }
     }
 
     /// Return `true` iff the underlying message represents a MIDI note off event.
     pub fn is_note_off(&self) -> bool {
-	match self.message {
-	    OwnedLiveEvent::Midi { message: MidiMessage::NoteOn { .. }, .. } => true,
-	    _ => false
-	}
+        match self.message {
+            OwnedLiveEvent::Midi {
+                message: MidiMessage::NoteOn { .. },
+                ..
+            } => true,
+            _ => false,
+        }
     }
 }
 
@@ -269,7 +275,7 @@ impl Future for MidiInputTask {
                             stream.feed(message, |live_event| {
                                 let _ = s.send(Reply::Midi(MidiData {
                                     stamp,
-                                    message: live_event.to_static(),
+                                    message: live_event.into(),
                                 }));
                             });
                         },
@@ -316,10 +322,10 @@ impl Future for MidiInputTask {
                             &port,
                             self.settings.port_name,
                             move |stamp, message, _| {
-                                stream.feed(message, |event| {
+                                stream.feed(message, |live_event| {
                                     let _ = s.send(Reply::Midi(MidiData {
                                         stamp,
-                                        message: event.to_static(),
+                                        message: live_event.into(),
                                     }));
                                 })
                             },

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,11 @@
-use super::{MidiMessage, KEY_RANGE};
+use crate::MidiMessage;
+
 use bevy::prelude::Plugin;
 use bevy::{prelude::*, tasks::IoTaskPool};
 use crossbeam_channel::{Receiver, Sender};
 use midir::ConnectErrorKind; // XXX: do we expose this?
 pub use midir::{Ignore, MidiInputPort};
+use midly::stream::MidiStream;
 use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
@@ -240,14 +242,14 @@ impl Future for MidiInputTask {
                         .input
                         .take()
                         .unwrap_or_else(|| self.connection.take().unwrap().0.close().0);
+                    let mut stream = MidiStream::new();
                     let conn = i.connect(
                         &port,
                         self.settings.port_name,
                         move |stamp, message, _| {
-                            let _ = s.send(Reply::Midi(MidiData {
-                                stamp,
-                                message: [message[0], message[1], message[2]].into(),
-                            }));
+                            stream.feed(message, |live_event| {
+                                let _ = s.send(Reply::Midi(MidiData { stamp, message: live_event.to_static() }));
+                            });
                         },
                         (),
                     );
@@ -287,14 +289,17 @@ impl Future for MidiInputTask {
                         self.sender.send(get_available_ports(&i)).unwrap();
 
                         let s = self.sender.clone();
+			let mut stream = MidiStream::new();
                         let conn = i.connect(
                             &port,
                             self.settings.port_name,
                             move |stamp, message, _| {
-                                let _ = s.send(Reply::Midi(MidiData {
-                                    stamp,
-                                    message: [message[0], message[1], message[2]].into(),
-                                }));
+				stream.feed(message, |event| {
+                                    let _ = s.send(Reply::Midi(MidiData {
+					stamp,
+					message: event.to_static()
+                                    }));
+				})
                             },
                             (),
                         );
@@ -343,16 +348,17 @@ fn get_available_ports(input: &midir::MidiInput) -> Reply {
 // A system which debug prints note events
 fn debug(mut midi: EventReader<MidiData>) {
     for data in midi.read() {
-        let pitch = data.message.msg[1];
-        let octave = pitch / 12;
-        let key = KEY_RANGE[pitch as usize % 12];
+	debug!("{:?}", data.message);
+        // let pitch = data.message.msg[1];
+        // let octave = pitch / 12;
+        // let key = KEY_RANGE[pitch as usize % 12];
 
-        if data.message.is_note_on() {
-            debug!("NoteOn: {}{:?} - Raw: {:?}", key, octave, data.message.msg);
-        } else if data.message.is_note_off() {
-            debug!("NoteOff: {}{:?} - Raw: {:?}", key, octave, data.message.msg);
-        } else {
-            debug!("Other: {:?}", data.message.msg);
-        }
+        // if data.message.is_note_on() {
+        //     debug!("NoteOn: {}{:?} - Raw: {:?}", key, octave, data.message.msg);
+        // } else if data.message.is_note_off() {
+        //     debug!("NoteOff: {}{:?} - Raw: {:?}", key, octave, data.message.msg);
+        // } else {
+        //     debug!("Other: {:?}", data.message.msg);
+        // }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
-pub use midly::live::{LiveEvent, SystemCommon, SystemRealtime};
-pub use midly::MidiMessage;
+use midly::live::{LiveEvent, SystemCommon};
+pub use midly::{
+    live::{MtcQuarterFrameMessage, SystemRealtime},
+    MidiMessage,
+};
 
 /// Re-export [`midly::num`] module.
 pub mod num {
@@ -17,4 +20,122 @@ pub const KEY_RANGE: [&str; 12] = [
     "C", "C#/Db", "D", "D#/Eb", "E", "F", "F#/Gb", "G", "G#/Ab", "A", "A#/Bb", "B",
 ];
 
-pub type OwnedLiveEvent = LiveEvent<'static>;
+/// Owned version of a [`midly::live::LiveEvent`].
+///
+/// Standard [`midly::live::LiveEvent`]s have a lifetime parameter limiting them to the scope in
+/// which they are generated to avoid any copying. However, because we are sending these messages
+/// through the bevy event system, they need to outlive this original scope.
+///
+/// Creating [`OwnedLiveEvent`]s only allocates when the message is a an [`OwnedSystemCommon`] that
+/// itself contains an allocation.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub enum OwnedLiveEvent {
+    /// A midi message with a channel and music data.
+    Midi {
+        channel: num::u4,
+        message: midly::MidiMessage,
+    },
+
+    /// A System Common message with owned data.
+    Common(OwnedSystemCommon),
+
+    /// A one-byte System Realtime Message.
+    Realtime(SystemRealtime),
+}
+
+/// Owned version of [`midly::live::SystemCommon`].
+///
+/// [`OwnedSystemCommon`] fully owns any underlying value data, including
+/// [`OwnedSystemCommon::SysEx`] messages.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub enum OwnedSystemCommon {
+    /// A system-exclusive event.
+    ///
+    /// Only contains the data bytes; does not inclde the `0xF0` and `0xF6` begin/end marker bytes.
+    /// slice does not include either: it only includes data bytes in the `0x00..=0x7F` range.
+    SysEx(Vec<num::u7>),
+    /// A MIDI Time Code Quarter Frame message, carrying a tag type and a 4-bit tag value.
+    MidiTimeCodeQuarterFrame(MtcQuarterFrameMessage, num::u4),
+    /// The number of MIDI beats (6 x MIDI clocks) that have elapsed since the start of the
+    /// sequence.
+    SongPosition(num::u14),
+    /// Select a given song index.
+    SongSelect(num::u7),
+    /// Request the device to tune itself.
+    TuneRequest,
+    /// An undefined System Common message, with arbitrary data bytes.
+    Undefined(u8, Vec<num::u7>),
+}
+
+impl OwnedLiveEvent {
+    /// Returns a [`MidiMessage::NoteOn`] event.
+    pub fn note_on<C: Into<num::u4>, K: Into<num::u7>, V: Into<num::u7>>(
+        channel: C,
+        key: K,
+        vel: V,
+    ) -> OwnedLiveEvent {
+        OwnedLiveEvent::Midi {
+            channel: channel.into(),
+            message: midly::MidiMessage::NoteOn {
+                key: key.into(),
+                vel: vel.into(),
+            },
+        }
+    }
+
+    /// Returns a [`MidiMessage::NoteOff`] event.
+    pub fn note_off<C: Into<num::u4>, K: Into<num::u7>, V: Into<num::u7>>(
+        channel: C,
+        key: K,
+        vel: V,
+    ) -> OwnedLiveEvent {
+        OwnedLiveEvent::Midi {
+            channel: channel.into(),
+            message: midly::MidiMessage::NoteOff {
+                key: key.into(),
+                vel: vel.into(),
+            },
+        }
+    }
+}
+
+impl<'a> From<LiveEvent<'a>> for OwnedLiveEvent {
+    fn from(value: LiveEvent) -> Self {
+        match value {
+            LiveEvent::Midi { channel, message } => OwnedLiveEvent::Midi { channel, message },
+            LiveEvent::Realtime(rt) => OwnedLiveEvent::Realtime(rt),
+            LiveEvent::Common(sc) => OwnedLiveEvent::Common(match sc {
+                SystemCommon::MidiTimeCodeQuarterFrame(m, v) => {
+                    OwnedSystemCommon::MidiTimeCodeQuarterFrame(m, v)
+                }
+                SystemCommon::SongPosition(pos) => OwnedSystemCommon::SongPosition(pos),
+                SystemCommon::SongSelect(ss) => OwnedSystemCommon::SongSelect(ss),
+                SystemCommon::TuneRequest => OwnedSystemCommon::TuneRequest,
+                SystemCommon::SysEx(b) => OwnedSystemCommon::SysEx(b.to_vec()),
+                SystemCommon::Undefined(tag, b) => OwnedSystemCommon::Undefined(tag, b.to_vec()),
+            }),
+        }
+    }
+}
+
+impl<'a, 'b: 'a> From<&'b OwnedLiveEvent> for LiveEvent<'a> {
+    fn from(value: &'b OwnedLiveEvent) -> Self {
+        match value {
+            OwnedLiveEvent::Midi { channel, message } => LiveEvent::Midi {
+                channel: *channel,
+                message: *message,
+            },
+            OwnedLiveEvent::Realtime(rt) => LiveEvent::Realtime(*rt),
+            OwnedLiveEvent::Common(sc) => LiveEvent::Common(match sc {
+                OwnedSystemCommon::MidiTimeCodeQuarterFrame(m, v) => {
+                    SystemCommon::MidiTimeCodeQuarterFrame(*m, *v)
+                }
+                OwnedSystemCommon::SongPosition(pos) => SystemCommon::SongPosition(*pos),
+                OwnedSystemCommon::SongSelect(ss) => SystemCommon::SongSelect(*ss),
+                OwnedSystemCommon::TuneRequest => SystemCommon::TuneRequest,
+                OwnedSystemCommon::SysEx(b) => SystemCommon::SysEx(&b),
+                OwnedSystemCommon::Undefined(tag, b) => SystemCommon::Undefined(*tag, &b),
+            }),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,141 +1,16 @@
-use midly::live::{LiveEvent, SystemCommon};
-pub use midly::{
-    live::{MtcQuarterFrameMessage, SystemRealtime},
-    MidiMessage,
-};
-
-/// Re-export [`midly::num`] module.
+/// Re-export [`midly::num`] module .
 pub mod num {
     pub use midly::num::{u14, u15, u24, u28, u4, u7};
 }
 
 pub mod input;
 pub mod output;
+pub mod types;
 
 pub mod prelude {
-    pub use crate::{input::*, output::*, *};
+    pub use crate::{input::*, output::*, types::*, *};
 }
 
 pub const KEY_RANGE: [&str; 12] = [
     "C", "C#/Db", "D", "D#/Eb", "E", "F", "F#/Gb", "G", "G#/Ab", "A", "A#/Bb", "B",
 ];
-
-/// Owned version of a [`midly::live::LiveEvent`].
-///
-/// Standard [`midly::live::LiveEvent`]s have a lifetime parameter limiting them to the scope in
-/// which they are generated to avoid any copying. However, because we are sending these messages
-/// through the bevy event system, they need to outlive this original scope.
-///
-/// Creating [`OwnedLiveEvent`]s only allocates when the message is a an [`OwnedSystemCommon`] that
-/// itself contains an allocation.
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub enum OwnedLiveEvent {
-    /// A midi message with a channel and music data.
-    Midi {
-        channel: num::u4,
-        message: midly::MidiMessage,
-    },
-
-    /// A System Common message with owned data.
-    Common(OwnedSystemCommon),
-
-    /// A one-byte System Realtime Message.
-    Realtime(SystemRealtime),
-}
-
-/// Owned version of [`midly::live::SystemCommon`].
-///
-/// [`OwnedSystemCommon`] fully owns any underlying value data, including
-/// [`OwnedSystemCommon::SysEx`] messages.
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub enum OwnedSystemCommon {
-    /// A system-exclusive event.
-    ///
-    /// Only contains the data bytes; does not inclde the `0xF0` and `0xF6` begin/end marker bytes.
-    /// slice does not include either: it only includes data bytes in the `0x00..=0x7F` range.
-    SysEx(Vec<num::u7>),
-    /// A MIDI Time Code Quarter Frame message, carrying a tag type and a 4-bit tag value.
-    MidiTimeCodeQuarterFrame(MtcQuarterFrameMessage, num::u4),
-    /// The number of MIDI beats (6 x MIDI clocks) that have elapsed since the start of the
-    /// sequence.
-    SongPosition(num::u14),
-    /// Select a given song index.
-    SongSelect(num::u7),
-    /// Request the device to tune itself.
-    TuneRequest,
-    /// An undefined System Common message, with arbitrary data bytes.
-    Undefined(u8, Vec<num::u7>),
-}
-
-impl OwnedLiveEvent {
-    /// Returns a [`MidiMessage::NoteOn`] event.
-    pub fn note_on<C: Into<num::u4>, K: Into<num::u7>, V: Into<num::u7>>(
-        channel: C,
-        key: K,
-        vel: V,
-    ) -> OwnedLiveEvent {
-        OwnedLiveEvent::Midi {
-            channel: channel.into(),
-            message: midly::MidiMessage::NoteOn {
-                key: key.into(),
-                vel: vel.into(),
-            },
-        }
-    }
-
-    /// Returns a [`MidiMessage::NoteOff`] event.
-    pub fn note_off<C: Into<num::u4>, K: Into<num::u7>, V: Into<num::u7>>(
-        channel: C,
-        key: K,
-        vel: V,
-    ) -> OwnedLiveEvent {
-        OwnedLiveEvent::Midi {
-            channel: channel.into(),
-            message: midly::MidiMessage::NoteOff {
-                key: key.into(),
-                vel: vel.into(),
-            },
-        }
-    }
-}
-
-impl<'a> From<LiveEvent<'a>> for OwnedLiveEvent {
-    fn from(value: LiveEvent) -> Self {
-        match value {
-            LiveEvent::Midi { channel, message } => OwnedLiveEvent::Midi { channel, message },
-            LiveEvent::Realtime(rt) => OwnedLiveEvent::Realtime(rt),
-            LiveEvent::Common(sc) => OwnedLiveEvent::Common(match sc {
-                SystemCommon::MidiTimeCodeQuarterFrame(m, v) => {
-                    OwnedSystemCommon::MidiTimeCodeQuarterFrame(m, v)
-                }
-                SystemCommon::SongPosition(pos) => OwnedSystemCommon::SongPosition(pos),
-                SystemCommon::SongSelect(ss) => OwnedSystemCommon::SongSelect(ss),
-                SystemCommon::TuneRequest => OwnedSystemCommon::TuneRequest,
-                SystemCommon::SysEx(b) => OwnedSystemCommon::SysEx(b.to_vec()),
-                SystemCommon::Undefined(tag, b) => OwnedSystemCommon::Undefined(tag, b.to_vec()),
-            }),
-        }
-    }
-}
-
-impl<'a, 'b: 'a> From<&'b OwnedLiveEvent> for LiveEvent<'a> {
-    fn from(value: &'b OwnedLiveEvent) -> Self {
-        match value {
-            OwnedLiveEvent::Midi { channel, message } => LiveEvent::Midi {
-                channel: *channel,
-                message: *message,
-            },
-            OwnedLiveEvent::Realtime(rt) => LiveEvent::Realtime(*rt),
-            OwnedLiveEvent::Common(sc) => LiveEvent::Common(match sc {
-                OwnedSystemCommon::MidiTimeCodeQuarterFrame(m, v) => {
-                    SystemCommon::MidiTimeCodeQuarterFrame(*m, *v)
-                }
-                OwnedSystemCommon::SongPosition(pos) => SystemCommon::SongPosition(*pos),
-                OwnedSystemCommon::SongSelect(ss) => SystemCommon::SongSelect(*ss),
-                OwnedSystemCommon::TuneRequest => SystemCommon::TuneRequest,
-                OwnedSystemCommon::SysEx(b) => SystemCommon::SysEx(&b),
-                OwnedSystemCommon::Undefined(tag, b) => SystemCommon::Undefined(*tag, &b),
-            }),
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
-use midly::live::LiveEvent;
+pub use midly::live::{LiveEvent, SystemCommon, SystemRealtime};
+pub use midly::MidiMessage;
+
+/// Re-export [`midly::num`] module.
+pub mod num {
+    pub use midly::num::{u14, u15, u24, u28, u4, u7};
+}
 
 pub mod input;
 pub mod output;
@@ -11,4 +17,4 @@ pub const KEY_RANGE: [&str; 12] = [
     "C", "C#/Db", "D", "D#/Eb", "E", "F", "F#/Gb", "G", "G#/Ab", "A", "A#/Bb", "B",
 ];
 
-pub type MidiMessage = LiveEvent<'static>;
+pub type OwnedLiveEvent = LiveEvent<'static>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use midly::live::LiveEvent;
+
 pub mod input;
 pub mod output;
 
@@ -9,34 +11,4 @@ pub const KEY_RANGE: [&str; 12] = [
     "C", "C#/Db", "D", "D#/Eb", "E", "F", "F#/Gb", "G", "G#/Ab", "A", "A#/Bb", "B",
 ];
 
-const NOTE_ON_STATUS: u8 = 0b1001_0000;
-const NOTE_OFF_STATUS: u8 = 0b1000_0000;
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct MidiMessage {
-    pub msg: [u8; 3],
-}
-
-impl From<[u8; 3]> for MidiMessage {
-    fn from(msg: [u8; 3]) -> Self {
-        MidiMessage { msg }
-    }
-}
-
-impl MidiMessage {
-    #[must_use]
-    pub fn is_note_on(&self) -> bool {
-        (self.msg[0] & 0b1111_0000) == NOTE_ON_STATUS
-    }
-
-    #[must_use]
-    pub fn is_note_off(&self) -> bool {
-        (self.msg[0] & 0b1111_0000) == NOTE_OFF_STATUS
-    }
-
-    /// Get the channel of a message, assuming the message is not a system message.
-    #[must_use]
-    pub fn channel(&self) -> u8 {
-        self.msg[0] & 0b0000_1111
-    }
-}
+pub type MidiMessage = LiveEvent<'static>;

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 use std::{error::Error, future::Future};
 use MidiOutputError::{ConnectionError, PortRefreshError, SendDisconnectedError, SendError};
 
-use crate::OwnedLiveEvent;
+use crate::types::OwnedLiveEvent;
 
 pub struct MidiOutputPlugin;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -285,7 +285,8 @@ impl Future for MidiOutputTask {
                 Midi(message) => {
                     if let Some((conn, _)) = &mut self.connection {
                         let mut byte_msg = Vec::with_capacity(4);
-                        match message.write_std(&mut byte_msg) {
+                        let live: midly::live::LiveEvent = (&message).into();
+                        match live.write_std(&mut byte_msg) {
                             Ok(_) => {
                                 if let Err(e) = conn.send(&byte_msg) {
                                     self.sender.send(Reply::Error(SendError(e))).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,128 @@
+//! Module definined owned variants of `[midly]` structures. These owned variants allow for more
+//! ergonomic usage.
+use midly::live::{LiveEvent, SystemCommon};
+use midly::num;
+pub use midly::{
+    live::{MtcQuarterFrameMessage, SystemRealtime},
+    MidiMessage,
+};
+
+/// Owned version of a [`midly::live::LiveEvent`].
+///
+/// Standard [`midly::live::LiveEvent`]s have a lifetime parameter limiting them to the scope in
+/// which they are generated to avoid any copying. However, because we are sending these messages
+/// through the bevy event system, they need to outlive this original scope.
+///
+/// Creating [`OwnedLiveEvent`]s only allocates when the message is a an [`OwnedSystemCommon`] that
+/// itself contains an allocation.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub enum OwnedLiveEvent {
+    /// A midi message with a channel and music data.
+    Midi {
+        channel: num::u4,
+        message: midly::MidiMessage,
+    },
+
+    /// A System Common message with owned data.
+    Common(OwnedSystemCommon),
+
+    /// A one-byte System Realtime Message.
+    Realtime(SystemRealtime),
+}
+
+/// Owned version of [`midly::live::SystemCommon`].
+///
+/// [`OwnedSystemCommon`] fully owns any underlying value data, including
+/// [`OwnedSystemCommon::SysEx`] messages.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub enum OwnedSystemCommon {
+    /// A system-exclusive event.
+    ///
+    /// Only contains the data bytes; does not inclde the `0xF0` and `0xF6` begin/end marker bytes.
+    /// slice does not include either: it only includes data bytes in the `0x00..=0x7F` range.
+    SysEx(Vec<num::u7>),
+    /// A MIDI Time Code Quarter Frame message, carrying a tag type and a 4-bit tag value.
+    MidiTimeCodeQuarterFrame(MtcQuarterFrameMessage, num::u4),
+    /// The number of MIDI beats (6 x MIDI clocks) that have elapsed since the start of the
+    /// sequence.
+    SongPosition(num::u14),
+    /// Select a given song index.
+    SongSelect(num::u7),
+    /// Request the device to tune itself.
+    TuneRequest,
+    /// An undefined System Common message, with arbitrary data bytes.
+    Undefined(u8, Vec<num::u7>),
+}
+
+impl OwnedLiveEvent {
+    /// Returns a [`MidiMessage::NoteOn`] event.
+    pub fn note_on<C: Into<num::u4>, K: Into<num::u7>, V: Into<num::u7>>(
+        channel: C,
+        key: K,
+        vel: V,
+    ) -> OwnedLiveEvent {
+        OwnedLiveEvent::Midi {
+            channel: channel.into(),
+            message: midly::MidiMessage::NoteOn {
+                key: key.into(),
+                vel: vel.into(),
+            },
+        }
+    }
+
+    /// Returns a [`MidiMessage::NoteOff`] event.
+    pub fn note_off<C: Into<num::u4>, K: Into<num::u7>, V: Into<num::u7>>(
+        channel: C,
+        key: K,
+        vel: V,
+    ) -> OwnedLiveEvent {
+        OwnedLiveEvent::Midi {
+            channel: channel.into(),
+            message: midly::MidiMessage::NoteOff {
+                key: key.into(),
+                vel: vel.into(),
+            },
+        }
+    }
+}
+
+impl<'a> From<LiveEvent<'a>> for OwnedLiveEvent {
+    fn from(value: LiveEvent) -> Self {
+        match value {
+            LiveEvent::Midi { channel, message } => OwnedLiveEvent::Midi { channel, message },
+            LiveEvent::Realtime(rt) => OwnedLiveEvent::Realtime(rt),
+            LiveEvent::Common(sc) => OwnedLiveEvent::Common(match sc {
+                SystemCommon::MidiTimeCodeQuarterFrame(m, v) => {
+                    OwnedSystemCommon::MidiTimeCodeQuarterFrame(m, v)
+                }
+                SystemCommon::SongPosition(pos) => OwnedSystemCommon::SongPosition(pos),
+                SystemCommon::SongSelect(ss) => OwnedSystemCommon::SongSelect(ss),
+                SystemCommon::TuneRequest => OwnedSystemCommon::TuneRequest,
+                SystemCommon::SysEx(b) => OwnedSystemCommon::SysEx(b.to_vec()),
+                SystemCommon::Undefined(tag, b) => OwnedSystemCommon::Undefined(tag, b.to_vec()),
+            }),
+        }
+    }
+}
+
+impl<'a, 'b: 'a> From<&'b OwnedLiveEvent> for LiveEvent<'a> {
+    fn from(value: &'b OwnedLiveEvent) -> Self {
+        match value {
+            OwnedLiveEvent::Midi { channel, message } => LiveEvent::Midi {
+                channel: *channel,
+                message: *message,
+            },
+            OwnedLiveEvent::Realtime(rt) => LiveEvent::Realtime(*rt),
+            OwnedLiveEvent::Common(sc) => LiveEvent::Common(match sc {
+                OwnedSystemCommon::MidiTimeCodeQuarterFrame(m, v) => {
+                    SystemCommon::MidiTimeCodeQuarterFrame(*m, *v)
+                }
+                OwnedSystemCommon::SongPosition(pos) => SystemCommon::SongPosition(*pos),
+                OwnedSystemCommon::SongSelect(ss) => SystemCommon::SongSelect(*ss),
+                OwnedSystemCommon::TuneRequest => SystemCommon::TuneRequest,
+                OwnedSystemCommon::SysEx(b) => SystemCommon::SysEx(&b),
+                OwnedSystemCommon::Undefined(tag, b) => SystemCommon::Undefined(*tag, &b),
+            }),
+        }
+    }
+}


### PR DESCRIPTION
Initial branch based on the discussion in #35 . 

Docs are probably a little sparse; I wasn't sure what should be copied / re-worded vs. what isn't really necessary. 

