### PR TITLE
Upgrade to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,8 @@ repository = "https://github.com/BlackPhlox/bevy_midi"
 documentation = "https://docs.rs/bevy_midi"
 description = "Send and receive MIDI data to and from bevy and other programs or controllers."
 keywords = ["gamedev", "bevy", "midi", "encoding", "control"]
-categories = ["game-development", "game-engines", "encoding" ]
-exclude = [
-    ".github/*",
-    "assets/*"
-]
+categories = ["game-development", "game-engines", "encoding"]
+exclude = [".github/*", "assets/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -25,21 +22,20 @@ midir = "0.10"
 crossbeam-channel = "0.5.8"
 
 [dev-dependencies]
-bevy_egui = { version = "0.28", features = ["immutable_ctx"]}
+bevy_egui = { version = "0.31.1", features = ["immutable_ctx"] }
 strum = { version = "0.26", features = ["derive"] }
 bevy_mod_picking = "0.20"
 
 [dependencies.bevy]
-version = "0.14"
+version = "0.15"
 default-features = false
 features = ["multi_threaded"]
 
 [dev-dependencies.bevy]
-version = "0.14"
-features = ["bevy_core_pipeline","bevy_asset", "bevy_scene", "bevy_render", "bevy_winit", "bevy_gltf", "bevy_ui", "bevy_text", "zstd", "tonemapping_luts", "ktx2", "hdr"]
-default-features = false
+version = "0.15"
+default-features = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
-version = "0.14"
+version = "0.15"
 features = ["x11", "wayland"]
 default-features = false

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -93,7 +93,7 @@ fn show_connection(
     mut instructions: Query<(&mut TextSpan, &mut TextColor), With<ConnectStatus>>,
 ) {
     if connection.is_changed() {
-        let (mut text, mut color) = instructions.single_mut();
+        let (text, color) = &mut instructions.single_mut();
         if connection.is_connected() {
             text.0 = "Connected\n".to_string();
             color.0 = GREEN.into();

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -69,7 +69,7 @@ fn disconnect(keys: Res<ButtonInput<KeyCode>>, input: Res<MidiInput>) {
 }
 
 #[derive(Component)]
-pub struct Instructions;
+pub struct InputPorts;
 
 #[derive(Component)]
 pub struct ConnectStatus;
@@ -77,7 +77,7 @@ pub struct ConnectStatus;
 #[derive(Component)]
 pub struct Messages;
 
-fn show_ports(input: Res<MidiInput>, mut instructions: Query<&mut TextSpan, With<Instructions>>) {
+fn show_ports(input: Res<MidiInput>, mut instructions: Query<&mut TextSpan, With<InputPorts>>) {
     if input.is_changed() {
         let text = &mut instructions.single_mut();
         text.0 = "Available input ports:\n\n".to_string();
@@ -135,7 +135,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 font_size: 30.0,
                 ..default()
             },
-            Instructions,
         ))
         .with_children(|commands| {
             commands.spawn((
@@ -151,7 +150,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
                 TextColor(Color::WHITE),
-                Instructions,
+            ));
+            commands.spawn((
+                TextSpan::default(),
+                TextFont {
+                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font_size: 30.0,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+                InputPorts,
             ));
             commands.spawn((
                 TextSpan::new("Disconnected\n"),

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -83,12 +83,12 @@ fn play_notes(input: Res<ButtonInput<KeyCode>>, output: Res<MidiOutput>) {
 }
 
 #[derive(Component)]
-pub struct Instructions;
+pub struct OutputPorts;
 
 #[derive(Component)]
 pub struct ConnectStatus;
 
-fn show_ports(output: Res<MidiOutput>, mut instructions: Query<&mut TextSpan, With<Instructions>>) {
+fn show_ports(output: Res<MidiOutput>, mut instructions: Query<&mut TextSpan, With<OutputPorts>>) {
     if output.is_changed() {
         let text = &mut instructions.single_mut();
         text.0 = "Available output ports:\n\n".to_string();
@@ -101,7 +101,7 @@ fn show_ports(output: Res<MidiOutput>, mut instructions: Query<&mut TextSpan, Wi
 
 fn show_connection(
     connection: Res<MidiOutputConnection>,
-    mut instructions: Query<(&mut Text, &mut TextColor), With<ConnectStatus>>,
+    mut instructions: Query<(&mut TextSpan, &mut TextColor), With<ConnectStatus>>,
 ) {
     if connection.is_changed() {
         let (text, color) = &mut instructions.single_mut();
@@ -126,7 +126,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 font_size: 30.0,
                 ..default()
             },
-            Instructions,
         ))
         .with_children(|commands| {
             commands.spawn((
@@ -143,7 +142,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 },
                 TextColor(Color::WHITE),
-                Instructions,
+            ));
+            commands.spawn((
+                TextSpan::default(),
+                TextFont {
+                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font_size: 30.0,
+                    ..default()
+                },
+                TextColor(Color::BLACK),
+                OutputPorts,
             ));
             commands.spawn((
                 TextSpan::new("Disconnected\n"),

--- a/examples/piano.rs
+++ b/examples/piano.rs
@@ -4,11 +4,10 @@ use bevy::{
     prelude::*,
 };
 use bevy_midi::prelude::*;
-use bevy_mod_picking::prelude::*;
+use bevy_mod_picking::prelude::{DefaultPickingPlugins, *};
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 1.0 / 5.0f32,
@@ -55,17 +54,16 @@ fn setup(
     let mid = -6.3;
 
     // light
-    cmds.spawn(PointLightBundle {
-        transform: Transform::from_xyz(0.0, 6.0, mid),
-        ..Default::default()
-    });
+    cmds.spawn((
+        PointLight::default(),
+        Transform::from_xyz(0.0, 6.0, mid)
+    ));
 
     //Camera
     cmds.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(8., 5., mid).looking_at(Vec3::new(0., 0., mid), Vec3::Y),
-            ..Default::default()
-        },
+        Camera3d::default(),
+        Msaa::Sample4,
+        Transform::from_xyz(8., 5., mid).looking_at(Vec3::new(0., 0., mid), Vec3::Y)
     ));
 
     let pos: Vec3 = Vec3::new(0., 0., 0.);
@@ -79,7 +77,7 @@ fn setup(
 
     //Create keyboard layout
     let pos_black = pos + Vec3::new(0., 0.06, 0.);
-    
+
     for i in 0..8 {
         spawn_note(&mut cmds, &w_mat, 0.00, pos, &mut white_key_0, i, "C");
         spawn_note(&mut cmds, &b_mat, 0.15, pos_black, &mut black_key, i, "C#/Db");
@@ -106,14 +104,11 @@ fn spawn_note(
     key: &str,
 ) {
     commands.spawn((
-        PbrBundle {
-            mesh: asset.clone(),
-            material: mat.clone(),
-            transform: Transform {
-                translation: Vec3::new(pos.x, pos.y, pos.z - offset_z - (1.61 * oct as f32)),
-                scale: Vec3::new(10., 10., 10.),
-                ..Default::default()
-            },
+        Mesh3d(asset.clone()),
+        MeshMaterial3d(mat.clone()),
+        Transform {
+            translation: Vec3::new(pos.x, pos.y, pos.z - offset_z - (1.61 * oct as f32)),
+            scale: Vec3::new(10., 10., 10.),
             ..Default::default()
         },
         Key {


### PR DESCRIPTION
Hello! I'd like to use your crate in 0.15. There are a few snags upgrading detailed below. Not sure how you'd like me to handle these. In general though, the upgrade works!

- Upgraded bevy to 0.15
- Set `all-features` to true for dev-dependencies. Workaround for https://github.com/bevyengine/bevy/issues/16671
- Updated examples (excepting `piano.rs`) to use updated Components (Existing bundles were deprecated. `TextSection` appears to have been removed)
  - Noted that `bevy_mod_picking`  is not ready for 0.15: https://github.com/aevyrie/bevy_mod_picking/issues/375. This dependency is used by the `piano` example. I'll see to removing it
  - Separately, `input.rs` always panics on connect on my computer, including on the main branch. I'll look to fix.

I'm not sure how you would like to proceed on the `piano.rs` example. I think this example is possible without this dependency.

Additionally, would it be alright to lock dependency versioning for this crate (remove `Cargo.lock` from `.gitignore`)? I would like to ensure consistent behavior for this crate since bevy is a tumultuous ecosystem.