### PR TITLE
fix: panic on connect to input

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -241,6 +241,9 @@ impl Future for MidiInputTask {
                         &port,
                         self.settings.port_name,
                         move |stamp, message, _| {
+                            if message.len() != 3 {
+                                return;
+                            }
                             let _ = s.send(Reply::Midi(MidiData {
                                 stamp,
                                 message: [message[0], message[1], message[2]].into(),


### PR DESCRIPTION
Checking that the input length is equal to 3 is my band-aid to deal with timing + sensing commands from the keyboard. 

Fixes https://github.com/BlackPhlox/bevy_midi/issues/42, https://github.com/BlackPhlox/bevy_midi/issues/28

This PR conflicts with https://github.com/BlackPhlox/bevy_midi/pull/29. However, I would recommend NOT merging that PR for two reasons:
1. This crate, as mentioned in https://github.com/BlackPhlox/bevy_midi/issues/35 handles only two messages properly: `note is on` and `note is off`. While handling other messages is most likely a future directive of this crate, I believe that the **current** crate structure should not, and cannot account for other statuses without `midly` or a significant structural change.
2. Zeroed data bytes mean different things for different statuses. So, this *might* do nothing, but I believe it would make more sense to throw away statuses without data bytes given the current implementation. Not doing this could be deceptive. In the example provided by #28, You will see that the data-less messages passed are the same status of `active sensing`. This crate in a vacuum, however, doesn't have the capability, nor should be capable of handling that case until comprehensive message parsing is resolved.

Obviously then, there's a pitfall of this PR as well. ONLY status types with 2 data bytes are available in the Resource. This means that the publicity of the message is incomplete. I'd argue this is okay, for now, but providing invalid zeroed data to a status without those bytes is far more deceptive when implementing logic. Of course, I'm assuming most dependents use the `is_note_on` and `is_note_off` methods exclusively, and parse the provided bytes afterwards.

Maybe then, the `MidiMessage` struct should be changed to

```rust
#[derive(Debug, Clone, Copy, Eq, PartialEq)]
pub struct MidiMessage {
    pub status: u8,
    pub d1: Option<u8>,
    pub d2: Option<u8>
}
```

Or even better:
```rust
#[derive(Debug, Clone, Copy, Eq, PartialEq)]
pub enum MidiMessage {
    NoteOn(Channel, u8, u8), // Could get *real* fancy, parsing status + data pair as a particular key and newtype Velocity
    SongSelect(u8),
    ActiveSensing,
    // i.e.
    TimeSignature(Notation, u8, u8), //Clocks per click, 32nd notes per 24 clocks
    NoteOff(Channel, Key, Velocity),
    ...
}

impl MidiMessage {
    pub fn is_note_on(&self) -> bool {
        match self {
            MidiMessage::NoteOn(_, velocity) => velocity != 0,
            MidiMessage::NoteOff(_, _) => true,
            _ => false
        }
    }

    pub fn velocity(&self) -> Option<u8> {
        match self {
            MidiMessage::NoteOn(_, velocity) | 
            MidiMessage::NoteOff(_, velocity) => velocity,
            _ => false
        }
    }
    ...
}
```

Or, I can just help implement `midly` for this crate, as correct parsing of statuses will be important to me soon. Thanks for your consideration!!
