### PR TITLE
Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_midi"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Black Phlox <bphlox@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_gltf",
+    "bevy_picking",
     "bevy_render",
     "bevy_scene",
     "bevy_text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_midi"
 version = "0.10.0"
 authors = ["Black Phlox <bphlox@gmail.com>"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/BlackPhlox/bevy_midi"
@@ -26,15 +26,16 @@ bevy_egui = { version = "0.31.1", features = ["immutable_ctx"] }
 strum = { version = "0.26", features = ["derive"] }
 
 [dependencies.bevy]
-version = "0.15"
+version = "0.16"
 default-features = false
-features = ["multi_threaded"]
+features = ["multi_threaded", "bevy_log"]
 
 [dev-dependencies.bevy]
-version = "0.15"
-default-features = true
+version = "0.16"
+features = ["bevy_core_pipeline","bevy_asset", "bevy_scene", "bevy_render", "bevy_winit", "bevy_gltf", "bevy_ui", "bevy_text", "zstd", "tonemapping_luts", "ktx2", "hdr"]
+default-features = false
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
-version = "0.15"
+version = "0.16"
 features = ["x11", "wayland"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,20 @@ features = ["multi_threaded", "bevy_log"]
 
 [dev-dependencies.bevy]
 version = "0.16"
-features = ["bevy_core_pipeline","bevy_asset", "bevy_scene", "bevy_render", "bevy_winit", "bevy_gltf", "bevy_ui", "bevy_text", "zstd", "tonemapping_luts", "ktx2", "hdr"]
+features = [
+    "bevy_asset",
+    "bevy_core_pipeline",
+    "bevy_gltf",
+    "bevy_render",
+    "bevy_scene",
+    "bevy_text",
+    "bevy_ui",
+    "bevy_winit",
+    "hdr",
+    "ktx2",
+    "tonemapping_luts",
+    "zstd"
+]
 default-features = false
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ midir = "0.10"
 crossbeam-channel = "0.5.8"
 
 [dev-dependencies]
-bevy_egui = { version = "0.31.1", features = ["immutable_ctx"] }
+bevy_egui = { version = "0.36", features = ["immutable_ctx"] }
 strum = { version = "0.26", features = ["derive"] }
 
 [dependencies.bevy]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See examples
 |0.13|0.8.X|
 |0.14|0.9.X|
 |0.15|0.10.X|
+|0.16|0.11.X|
 
 # Licensing
 The project is under dual license MIT and Apache 2.0, so joink to your hearts content, just remember the license agreements.

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -77,23 +77,27 @@ pub struct ConnectStatus;
 #[derive(Component)]
 pub struct Messages;
 
-fn show_ports(input: Res<MidiInput>, mut instructions: Query<&mut TextSpan, With<InputPorts>>) {
+fn show_ports(
+    input: Res<MidiInput>,
+    mut instructions: Query<&mut TextSpan, With<InputPorts>>,
+) -> Result {
     if input.is_changed() {
-        let text = &mut instructions.single_mut();
+        let text = &mut instructions.single_mut()?;
         text.0 = "Available input ports:\n\n".to_string();
         for (i, (name, _)) in input.ports().iter().enumerate() {
             text.0
                 .push_str(format!("Port {:?}: {:?}\n", i, name).as_str());
         }
     }
+    Ok(())
 }
 
 fn show_connection(
     connection: Res<MidiInputConnection>,
     mut instructions: Query<(&mut TextSpan, &mut TextColor), With<ConnectStatus>>,
-) {
+) -> Result {
     if connection.is_changed() {
-        let (text, color) = &mut instructions.single_mut();
+        let (text, color) = &mut instructions.single_mut()?;
         if connection.is_connected() {
             text.0 = "Connected\n".to_string();
             color.0 = GREEN.into();
@@ -102,14 +106,15 @@ fn show_connection(
             color.0 = RED.into();
         }
     }
+    Ok(())
 }
 
 fn show_last_message(
     mut midi_data: EventReader<MidiData>,
     mut instructions: Query<&mut TextSpan, With<Messages>>,
-) {
+) -> Result {
     for data in midi_data.read() {
-        let text = &mut instructions.single_mut();
+        let text = &mut instructions.single_mut()?;
         text.0 = format!(
             "Last Message: {} - {:?}",
             if data.message.is_note_on() {
@@ -122,6 +127,7 @@ fn show_last_message(
             data.message.msg
         );
     }
+    Ok(())
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -88,23 +88,27 @@ pub struct OutputPorts;
 #[derive(Component)]
 pub struct ConnectStatus;
 
-fn show_ports(output: Res<MidiOutput>, mut instructions: Query<&mut TextSpan, With<OutputPorts>>) {
+fn show_ports(
+    output: Res<MidiOutput>,
+    mut instructions: Query<&mut TextSpan, With<OutputPorts>>,
+) -> Result {
     if output.is_changed() {
-        let text = &mut instructions.single_mut();
+        let text = &mut instructions.single_mut()?;
         text.0 = "Available output ports:\n\n".to_string();
         for (i, (name, _)) in output.ports().iter().enumerate() {
             text.0
                 .push_str(format!("Port {:?}: {:?}\n", i, name).as_str());
         }
     }
+    Ok(())
 }
 
 fn show_connection(
     connection: Res<MidiOutputConnection>,
     mut instructions: Query<(&mut TextSpan, &mut TextColor), With<ConnectStatus>>,
-) {
+) -> Result {
     if connection.is_changed() {
-        let (text, color) = &mut instructions.single_mut();
+        let (text, color) = &mut instructions.single_mut()?;
         if connection.is_connected() {
             text.0 = "Connected".to_string();
             color.0 = GREEN.into();
@@ -113,6 +117,7 @@ fn show_connection(
             color.0 = RED.into();
         }
     }
+    Ok(())
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/examples/piano.rs
+++ b/examples/piano.rs
@@ -10,6 +10,7 @@ fn main() {
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 1.0 / 5.0f32,
+            ..default()
         })
         .add_plugins(DefaultPlugins.set(LogPlugin {
             level: Level::WARN,
@@ -116,12 +117,14 @@ fn spawn_note(
                 y_reset: pos.y,
             },
         ))
-        .observe(|click: Trigger<Pointer<Down>>, mut commands: Commands| {
-            commands.entity(click.entity()).insert(PressedKey);
+        .observe(|click: Trigger<Pointer<Pressed>>, mut commands: Commands| {
+            commands.entity(click.target()).insert(PressedKey);
         })
-        .observe(|release: Trigger<Pointer<Up>>, mut commands: Commands| {
-            commands.entity(release.entity()).remove::<PressedKey>();
-        });
+        .observe(
+            |release: Trigger<Pointer<Released>>, mut commands: Commands| {
+                commands.entity(release.target()).remove::<PressedKey>();
+            },
+        );
 }
 
 fn display_press(mut query: Query<&mut Transform, With<PressedKey>>) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,5 @@
-use super::{MidiMessage, KEY_RANGE};
+use super::{KEY_RANGE, MidiMessage};
+use MidiInputError::{ConnectionError, PortRefreshError};
 use bevy::prelude::Plugin;
 use bevy::{prelude::*, tasks::IoTaskPool};
 use crossbeam_channel::{Receiver, Sender};
@@ -7,7 +8,6 @@ pub use midir::{Ignore, MidiInputPort};
 use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
-use MidiInputError::{ConnectionError, PortRefreshError};
 
 pub struct MidiInputPlugin;
 
@@ -151,7 +151,7 @@ fn reply(
             }
             Reply::Error(e) => {
                 warn!("{}", e);
-                err.send(e);
+                err.write(e);
             }
             Reply::Connected => {
                 conn.connected = true;
@@ -160,7 +160,7 @@ fn reply(
                 conn.connected = false;
             }
             Reply::Midi(m) => {
-                midi.send(m);
+                midi.write(m);
             }
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,5 @@
 use super::MidiMessage;
+use MidiOutputError::{ConnectionError, PortRefreshError, SendDisconnectedError, SendError};
 use bevy::prelude::*;
 use bevy::tasks::IoTaskPool;
 use crossbeam_channel::{Receiver, Sender};
@@ -6,7 +7,6 @@ use midir::ConnectErrorKind;
 pub use midir::MidiOutputPort;
 use std::fmt::Display;
 use std::{error::Error, future::Future};
-use MidiOutputError::{ConnectionError, PortRefreshError, SendDisconnectedError, SendError};
 
 pub struct MidiOutputPlugin;
 
@@ -165,7 +165,7 @@ fn reply(
             }
             Reply::Error(e) => {
                 warn!("{}", e);
-                err.send(e);
+                err.write(e);
             }
             Reply::Connected => {
                 conn.connected = true;


### PR DESCRIPTION
Parts of this port was done on a branch in @rookboom's fork of bevy_midi, by another "johan" which is not me.

The original port was done from 0.14 to 0.16 directly, and disabled and refactored some of the examples. I rebased, fixed some of the conflicts, and re-did the example porting. So I guess this turned out to be mostly my work after all...